### PR TITLE
Remove helm v3 requirement

### DIFF
--- a/SCS-Spec.md
+++ b/SCS-Spec.md
@@ -314,10 +314,6 @@ Should provide registry with provider vetted images
 
 Should offer artifact security scanning
 
-### Helm - required
-
-Must provide helm v3
-
 ### Mesh - optional
 
 Should provide mesh discovery


### PR DESCRIPTION
While it is important to support the installation of resources via helm, IIRC there are no server-side helm components required any more since v3. So providing a compliant K8s cluster should be enough to enable helm deployments.

Instead of removing this requirement, it may also be rephrased, of course.

Signed-off-by: Joshua Mühlfort <muehlfort@gonicus.de>